### PR TITLE
Feature implementation from commits 5fdb6ad..f3f3301

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,8 @@ Documentation/
 examples/
 apple/WebRTC.xcframework
 apple/WebRTC.dSYMs
+android/build/
 *.jar
 *.tgz
 *.zip
+.github

--- a/Documentation/BasicUsage.md
+++ b/Documentation/BasicUsage.md
@@ -307,8 +307,13 @@ try {
 	// Taken from above, we don't want to flip if we don't have another camera.
 	if ( cameraCount < 2 ) { return; };
 
-	const videoTrack = await localMediaStream.getVideoTracks()[ 0 ];
-	videoTrack._switchCamera();
+	const videoTrack = localMediaStream.getVideoTracks()[0];
+	const constraints = { facingMode: isFrontCam ? 'user' : 'environment' };
+
+	videoTrack.applyConstraints(constraints);
+
+	// _switchCamera is deprecated as of 124.0.5
+	// videoTrack._switchCamera();
 
 	isFrontCam = !isFrontCam;
 } catch( err ) {

--- a/Documentation/iOSInstallation.md
+++ b/Documentation/iOSInstallation.md
@@ -26,6 +26,33 @@ Navigate to `<ProjectFolder>/ios/<ProjectName>/` and edit `Info.plist`, add the 
 <string>Microphone permission description</string>
 ```
 
+## CallKit
+
+If your app uses a CallKit integration to handle incoming calls, then your
+CXProviderDelegate should call through to `RTCAudioSession.sharedInstance.audioSessionDidActivate/Deactivate` accordingly.
+
+```
+#import <WebRTC/RTCAudioSession.h>
+
+- (void) provider:(CXProvider *) provider didActivateAudioSession:(AVAudioSession *) audioSession {
+    [[RTCAudioSession sharedInstance] audioSessionDidActivate:[AVAudioSession sharedInstance]];
+}
+
+- (void) provider:(CXProvider *) provider didDeactivateAudioSession:(AVAudioSession *) audioSession {
+    [[RTCAudioSession sharedInstance] audioSessionDidDeactivate:[AVAudioSession sharedInstance]];
+}
+```
+
+Javascript methods are also provided to call these methods:
+
+```
+import { RTCAudioSession } from 'react-native-webrtc'
+
+// Call as needed.
+RTCAudioSession.audioSessionDidActivate();
+RTCAudioSession.audioSessionDidDeactivate();
+```
+
 ## Library not loaded/Code signature invalid
 
 This is an issue with iOS 13.3.1.  

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -8,9 +8,4 @@
                 android:foregroundServiceType="mediaProjection">
         </service>
     </application>
-    <uses-feature
-        android:name="android.hardware.usb.host"
-        android:required="false"
-        tools:node="replace"
-    />
 </manifest>

--- a/android/src/main/java/com/oney/WebRTCModule/AbstractVideoCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/AbstractVideoCaptureController.java
@@ -3,9 +3,13 @@ package com.oney.WebRTCModule;
 import org.webrtc.VideoCapturer;
 
 public abstract class AbstractVideoCaptureController {
-    private final int width;
-    private final int height;
-    private final int fps;
+    protected final int targetWidth;
+    protected final int targetHeight;
+    protected final int targetFps;
+
+    protected int actualWidth;
+    protected int actualHeight;
+    protected int actualFps;
 
     /**
      * {@link VideoCapturer} which this controller manages.
@@ -15,9 +19,12 @@ public abstract class AbstractVideoCaptureController {
     protected CapturerEventsListener capturerEventsListener;
 
     public AbstractVideoCaptureController(int width, int height, int fps) {
-        this.width = width;
-        this.height = height;
-        this.fps = fps;
+        this.targetWidth = width;
+        this.targetHeight = height;
+        this.targetFps = fps;
+        this.actualWidth = width;
+        this.actualHeight = height;
+        this.actualFps = fps;
     }
 
     public void initializeVideoCapturer() {
@@ -32,15 +39,15 @@ public abstract class AbstractVideoCaptureController {
     }
 
     public int getHeight() {
-        return height;
+        return actualHeight;
     }
 
     public int getWidth() {
-        return width;
+        return actualWidth;
     }
 
     public int getFrameRate() {
-        return fps;
+        return actualFps;
     }
 
     public VideoCapturer getVideoCapturer() {
@@ -49,7 +56,7 @@ public abstract class AbstractVideoCaptureController {
 
     public void startCapture() {
         try {
-            videoCapturer.startCapture(width, height, fps);
+            videoCapturer.startCapture(targetWidth, targetHeight, targetFps);
         } catch (RuntimeException e) {
             // XXX This can only fail if we initialize the capturer incorrectly,
             // which we don't. Thus, ignore any failures here since we trust

--- a/android/src/main/java/com/oney/WebRTCModule/AbstractVideoCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/AbstractVideoCaptureController.java
@@ -1,11 +1,18 @@
 package com.oney.WebRTCModule;
 
+import androidx.annotation.Nullable;
+import androidx.core.util.Consumer;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+
 import org.webrtc.VideoCapturer;
 
 public abstract class AbstractVideoCaptureController {
-    protected final int targetWidth;
-    protected final int targetHeight;
-    protected final int targetFps;
+    protected int targetWidth;
+    protected int targetHeight;
+    protected int targetFps;
 
     protected int actualWidth;
     protected int actualHeight;
@@ -31,6 +38,9 @@ public abstract class AbstractVideoCaptureController {
         videoCapturer = createVideoCapturer();
     }
 
+    @Nullable
+    public abstract String getDeviceId();
+
     public void dispose() {
         if (videoCapturer != null) {
             videoCapturer.dispose();
@@ -48,6 +58,16 @@ public abstract class AbstractVideoCaptureController {
 
     public int getFrameRate() {
         return actualFps;
+    }
+
+    public WritableMap getSettings() {
+        WritableMap settings = Arguments.createMap();
+        settings.putString("deviceId", getDeviceId());
+        settings.putString("groupId", "");
+        settings.putInt("height", getHeight());
+        settings.putInt("width", getWidth());
+        settings.putInt("frameRate", getFrameRate());
+        return settings;
     }
 
     public VideoCapturer getVideoCapturer() {
@@ -70,6 +90,12 @@ public abstract class AbstractVideoCaptureController {
             return true;
         } catch (InterruptedException e) {
             return false;
+        }
+    }
+
+    public void applyConstraints(ReadableMap constraints, @Nullable Consumer<Exception> onFinishedCallback) {
+        if (onFinishedCallback != null) {
+            onFinishedCallback.accept(new UnsupportedOperationException("This video track does not support applyConstraints."));
         }
     }
 

--- a/android/src/main/java/com/oney/WebRTCModule/CameraCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/CameraCaptureController.java
@@ -1,11 +1,20 @@
 package com.oney.WebRTCModule;
 
+import android.content.Context;
+import android.hardware.camera2.CameraManager;
 import android.util.Log;
+import android.util.Pair;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableMap;
 
+import org.webrtc.Camera1Capturer;
+import org.webrtc.Camera1Helper;
+import org.webrtc.Camera2Capturer;
+import org.webrtc.Camera2Helper;
 import org.webrtc.CameraEnumerator;
 import org.webrtc.CameraVideoCapturer;
+import org.webrtc.Size;
 import org.webrtc.VideoCapturer;
 
 import java.util.ArrayList;
@@ -19,6 +28,7 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
 
     private boolean isFrontFacing;
 
+    private final Context context;
     private final CameraEnumerator cameraEnumerator;
     private final ReadableMap constraints;
 
@@ -30,9 +40,10 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
      */
     private final CameraEventsHandler cameraEventsHandler = new CameraEventsHandler();
 
-    public CameraCaptureController(CameraEnumerator cameraEnumerator, ReadableMap constraints) {
+    public CameraCaptureController(Context context, CameraEnumerator cameraEnumerator, ReadableMap constraints) {
         super(constraints.getInt("width"), constraints.getInt("height"), constraints.getInt("frameRate"));
 
+        this.context = context;
         this.cameraEnumerator = cameraEnumerator;
         this.constraints = constraints;
     }
@@ -75,7 +86,30 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
         String deviceId = ReactBridgeUtil.getMapStrValue(this.constraints, "deviceId");
         String facingMode = ReactBridgeUtil.getMapStrValue(this.constraints, "facingMode");
 
-        return createVideoCapturer(deviceId, facingMode);
+        Pair<String, VideoCapturer> result = createVideoCapturer(deviceId, facingMode);
+        if(result == null) {
+            return null;
+        }
+
+        String cameraName = result.first;
+        VideoCapturer videoCapturer = result.second;
+
+        // Find actual capture format.
+        Size actualSize = null;
+        if (videoCapturer instanceof Camera1Capturer) {
+            int cameraId = Camera1Helper.getCameraId(cameraName);
+            actualSize = Camera1Helper.findClosestCaptureFormat(cameraId, targetWidth, targetHeight);
+        } else if (videoCapturer instanceof Camera2Capturer) {
+            CameraManager cameraManager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
+            actualSize = Camera2Helper.findClosestCaptureFormat(cameraManager, cameraName, targetWidth, targetHeight);
+        }
+
+        if (actualSize != null) {
+            actualWidth = actualSize.width;
+            actualHeight = actualSize.height;
+        }
+
+        return videoCapturer;
     }
 
     /**
@@ -117,10 +151,11 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
      * @param facingMode the facing of the requested video source such as
      * {@code user} and {@code environment}. If {@code null}, "user" is
      * presumed.
-     * @return a {@code VideoCapturer} satisfying the {@code facingMode} or
-     * {@code deviceId} constraint
+     * @return a pair containing the deviceId and {@code VideoCapturer} satisfying the {@code facingMode} or
+     * {@code deviceId} constraint, or null.
      */
-    private VideoCapturer createVideoCapturer(String deviceId, String facingMode) {
+    @Nullable
+    private Pair<String, VideoCapturer> createVideoCapturer(String deviceId, String facingMode) {
         String[] deviceNames = cameraEnumerator.getDeviceNames();
         List<String> failedDevices = new ArrayList<>();
 
@@ -139,7 +174,7 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
             if (videoCapturer != null) {
                 Log.d(TAG, message + " succeeded");
                 this.isFrontFacing = cameraEnumerator.isFrontFacing(cameraName);
-                return videoCapturer;
+                return new Pair(cameraName, videoCapturer);
             } else {
                 // fallback to facingMode
                 Log.d(TAG, message + " failed");
@@ -161,7 +196,7 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
             if (videoCapturer != null) {
                 Log.d(TAG, message + " succeeded");
                 this.isFrontFacing = cameraEnumerator.isFrontFacing(name);
-                return videoCapturer;
+                return new Pair(name, videoCapturer);
             } else {
                 Log.d(TAG, message + " failed");
                 failedDevices.add(name);
@@ -176,7 +211,7 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
                 if (videoCapturer != null) {
                     Log.d(TAG, message + " succeeded");
                     this.isFrontFacing = cameraEnumerator.isFrontFacing(name);
-                    return videoCapturer;
+                    return new Pair(name, videoCapturer);
                 } else {
                     Log.d(TAG, message + " failed");
                     failedDevices.add(name);

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -192,7 +192,7 @@ class GetUserMediaImpl {
             Log.d(TAG, "getUserMedia(video): " + videoConstraintsMap);
 
             CameraCaptureController cameraCaptureController =
-                    new CameraCaptureController(getCameraEnumerator(), videoConstraintsMap);
+                    new CameraCaptureController(reactContext.getCurrentActivity(), getCameraEnumerator(), videoConstraintsMap);
 
             videoTrack = createVideoTrack(cameraCaptureController);
         }

--- a/android/src/main/java/com/oney/WebRTCModule/ScreenCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/ScreenCaptureController.java
@@ -61,6 +61,11 @@ public class ScreenCaptureController extends AbstractVideoCaptureController {
     }
 
     @Override
+    public String getDeviceId() {
+        return "screen-capture";
+    }
+
+    @Override
     public void dispose() {
         MediaProjectionService.abort(context);
         super.dispose();

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -882,11 +882,13 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void mediaStreamTrackSwitchCamera(String id) {
+    public void mediaStreamTrackApplyConstraints(String id, ReadableMap constraints, Promise promise) {
         ThreadUtils.runOnExecutor(() -> {
             MediaStreamTrack track = getLocalTrack(id);
             if (track != null) {
-                getUserMediaImpl.switchCamera(id);
+                getUserMediaImpl.applyConstraints(id, constraints, promise);
+            } else {
+                promise.reject(new Exception("mediaStreamTrackApplyConstraints() could not find track " + id));
             }
         });
     }

--- a/android/src/main/java/org/webrtc/Camera1Helper.java
+++ b/android/src/main/java/org/webrtc/Camera1Helper.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023-2024 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.webrtc;
+
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A helper to access package-protected methods used in [Camera2Session]
+ * <p>
+ * Note: cameraId as used in the Camera1XXX classes refers to the index within the list of cameras.
+ *
+ * @suppress
+ */
+
+public class Camera1Helper {
+
+    public static int getCameraId(String deviceName) {
+        return Camera1Enumerator.getCameraIndex(deviceName);
+    }
+
+    @Nullable
+    public static List<CameraEnumerationAndroid.CaptureFormat> getSupportedFormats(int cameraId) {
+        return Camera1Enumerator.getSupportedFormats(cameraId);
+    }
+
+    public static Size findClosestCaptureFormat(int cameraId, int width, int height) {
+        List<CameraEnumerationAndroid.CaptureFormat> formats = getSupportedFormats(cameraId);
+
+        List<Size> sizes = new ArrayList<>();
+        if (formats != null) {
+            for (CameraEnumerationAndroid.CaptureFormat format : formats) {
+                sizes.add(new Size(format.width, format.height));
+            }
+        }
+
+        return CameraEnumerationAndroid.getClosestSupportedSize(sizes, width, height);
+    }
+}

--- a/android/src/main/java/org/webrtc/Camera2Helper.java
+++ b/android/src/main/java/org/webrtc/Camera2Helper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023-2024 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.webrtc;
+
+import android.hardware.camera2.CameraManager;
+
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A helper to access package-protected methods used in [Camera2Session]
+ * <p>
+ * Note: cameraId as used in the Camera2XXX classes refers to the id returned
+ * by [CameraManager.getCameraIdList].
+ */
+public class Camera2Helper {
+
+    @Nullable
+    public static List<CameraEnumerationAndroid.CaptureFormat> getSupportedFormats(CameraManager cameraManager, @Nullable String cameraId) {
+        return Camera2Enumerator.getSupportedFormats(cameraManager, cameraId);
+    }
+
+    public static Size findClosestCaptureFormat(CameraManager cameraManager, @Nullable String cameraId, int width, int height) {
+        List<CameraEnumerationAndroid.CaptureFormat> formats = getSupportedFormats(cameraManager, cameraId);
+
+        List<Size> sizes = new ArrayList<>();
+        if (formats != null) {
+            for (CameraEnumerationAndroid.CaptureFormat format : formats) {
+                sizes.add(new Size(format.width, format.height));
+            }
+        }
+
+        return CameraEnumerationAndroid.getClosestSupportedSize(sizes, width, height);
+    }
+}

--- a/examples/GumTestApp/ios/GumTestApp.xcodeproj/project.pbxproj
+++ b/examples/GumTestApp/ios/GumTestApp.xcodeproj/project.pbxproj
@@ -400,18 +400,12 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-GumTestApp/Pods-GumTestApp-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/Flipper-DoubleConversion/double-conversion.framework/double-conversion",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/Flipper-Glog/glog.framework/glog",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/JitsiWebRTC/WebRTC.framework/WebRTC",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL-Universal/OpenSSL.framework/OpenSSL",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/double-conversion.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/glog.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WebRTC.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -466,18 +460,12 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-GumTestApp-GumTestAppTests/Pods-GumTestApp-GumTestAppTests-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/Flipper-DoubleConversion/double-conversion.framework/double-conversion",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/Flipper-Glog/glog.framework/glog",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/JitsiWebRTC/WebRTC.framework/WebRTC",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL-Universal/OpenSSL.framework/OpenSSL",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/double-conversion.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/glog.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WebRTC.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/examples/GumTestApp/ios/Podfile
+++ b/examples/GumTestApp/ios/Podfile
@@ -13,7 +13,7 @@ prepare_react_native_project!
 #   dependencies: {
 #     ...(process.env.NO_FLIPPER ? { 'react-native-flipper': { platforms: { ios: null } } } : {}),
 # ```
-flipper_config = ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled
+flipper_config = FlipperConfiguration.disabled
 
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil

--- a/ios/RCTWebRTC.xcodeproj/project.pbxproj
+++ b/ios/RCTWebRTC.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		4EE3A8D425B841DD00FAA24A /* ScreenCapturer.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EE3A8CD25B841DD00FAA24A /* ScreenCapturer.m */; };
 		D3FF699919D2664B25C9D458 /* Pods_RCTWebRTC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A20F721AD842563B66292D5B /* Pods_RCTWebRTC.framework */; };
 		D74EF94829652169000742E1 /* TrackCapturerEventsEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = D74EF94629652169000742E1 /* TrackCapturerEventsEmitter.m */; };
+		D7F0711E2C6DC91F0031F594 /* WebRTCModule+RTCAudioSession.m in Sources */ = {isa = PBXBuildFile; fileRef = D7F0711D2C6DC91F0031F594 /* WebRTCModule+RTCAudioSession.m */; };
 		DEC96577264176C10052DB35 /* DataChannelWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = DEC96576264176C10052DB35 /* DataChannelWrapper.m */; };
 /* End PBXBuildFile section */
 
@@ -75,6 +76,7 @@
 		D74EF94529652148000742E1 /* CapturerEventsDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CapturerEventsDelegate.h; path = RCTWebRTC/CapturerEventsDelegate.h; sourceTree = SOURCE_ROOT; };
 		D74EF94629652169000742E1 /* TrackCapturerEventsEmitter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TrackCapturerEventsEmitter.m; path = RCTWebRTC/TrackCapturerEventsEmitter.m; sourceTree = SOURCE_ROOT; };
 		D74EF94729652169000742E1 /* TrackCapturerEventsEmitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TrackCapturerEventsEmitter.h; path = RCTWebRTC/TrackCapturerEventsEmitter.h; sourceTree = SOURCE_ROOT; };
+		D7F0711D2C6DC91F0031F594 /* WebRTCModule+RTCAudioSession.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = "WebRTCModule+RTCAudioSession.m"; path = "RCTWebRTC/WebRTCModule+RTCAudioSession.m"; sourceTree = SOURCE_ROOT; };
 		D7F99C122938F4E0000A2450 /* WebRTCModule+RTCMediaStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "WebRTCModule+RTCMediaStream.h"; path = "RCTWebRTC/WebRTCModule+RTCMediaStream.h"; sourceTree = SOURCE_ROOT; };
 		DEC96576264176C10052DB35 /* DataChannelWrapper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = DataChannelWrapper.m; path = RCTWebRTC/DataChannelWrapper.m; sourceTree = "<group>"; };
 		DEC96579264176DF0052DB35 /* DataChannelWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DataChannelWrapper.h; path = RCTWebRTC/DataChannelWrapper.h; sourceTree = "<group>"; };
@@ -131,6 +133,7 @@
 				4EE3A8AF25B8413200FAA24A /* VideoCaptureController.h */,
 				0BDDA6DF20C18B6B00B38B45 /* VideoCaptureController.m */,
 				4EE3A8B525B8414A00FAA24A /* WebRTCModule+Permissions.m */,
+				D7F0711D2C6DC91F0031F594 /* WebRTCModule+RTCAudioSession.m */,
 				4EE3A8B825B8415900FAA24A /* WebRTCModule+RTCDataChannel.h */,
 				4EE3A8B925B8415900FAA24A /* WebRTCModule+RTCDataChannel.m */,
 				D7F99C122938F4E0000A2450 /* WebRTCModule+RTCMediaStream.h */,
@@ -262,6 +265,7 @@
 				4EC498BC25B8777F00E76218 /* ScreenCapturePickerViewManager.m in Sources */,
 				4EE3A8B225B8414000FAA24A /* WebRTCModule.m in Sources */,
 				4EE3A8D225B841DD00FAA24A /* CaptureController.m in Sources */,
+				D7F0711E2C6DC91F0031F594 /* WebRTCModule+RTCAudioSession.m in Sources */,
 				D74EF94829652169000742E1 /* TrackCapturerEventsEmitter.m in Sources */,
 				4EE3A8D125B841DD00FAA24A /* SocketConnection.m in Sources */,
 				4EE3A8BD25B8416500FAA24A /* WebRTCModule+RTCMediaStream.m in Sources */,

--- a/ios/RCTWebRTC/CaptureController.h
+++ b/ios/RCTWebRTC/CaptureController.h
@@ -6,9 +6,12 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CaptureController : NSObject
 
 @property(nonatomic, strong) id<CapturerEventsDelegate> eventsDelegate;
+@property(nonatomic, copy, nullable) NSString* deviceId;
 
 - (void)startCapture;
 - (void)stopCapture;
+- (NSDictionary *)getSettings;
+- (void)applyConstraints:(NSDictionary *)constraints error:(NSError **)outError;
 
 @end
 

--- a/ios/RCTWebRTC/CaptureController.m
+++ b/ios/RCTWebRTC/CaptureController.m
@@ -12,6 +12,19 @@
     // subclasses needs to override
 }
 
+- (NSDictionary *) getSettings {
+    // subclasses needs to override
+    return @{
+        @"deviceId": self.deviceId
+    };
+}
+
+- (void)applyConstraints:(NSDictionary *)constraints error:(NSError **)outError {
+    *outError = [NSError errorWithDomain:@"react-native-webrtc"
+                                    code:0
+                                userInfo:@{ NSLocalizedDescriptionKey: @"This video track does not support applyConstraints."}];
+}
+
 @end
 
 #endif

--- a/ios/RCTWebRTC/RTCVideoViewManager.m
+++ b/ios/RCTWebRTC/RTCVideoViewManager.m
@@ -2,6 +2,8 @@
 #import <objc/runtime.h>
 
 #import <React/RCTLog.h>
+#import <React/RCTView.h>
+
 #import <WebRTC/RTCMediaStream.h>
 #if TARGET_OS_OSX
 #import <WebRTC/RTCMTLNSVideoView.h>
@@ -42,12 +44,7 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
  * Implements an equivalent of {@code HTMLVideoElement} i.e. Web's video
  * element.
  */
-
-#if TARGET_OS_OSX
-@interface RTCVideoView : NSView
-#else
-@interface RTCVideoView : UIView
-#endif
+@interface RTCVideoView : RCTView
 
 /**
  * The indicator which determines whether this {@code RTCVideoView} is to mirror
@@ -252,11 +249,7 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
 
 RCT_EXPORT_MODULE()
 
-#if TARGET_OS_OSX
-- (NSView *)view {
-#else
-- (UIView *)view {
-#endif
+- (RCTView *)view {
     RTCVideoView *v = [[RTCVideoView alloc] init];
     v.module = [self.bridge moduleForName:@"WebRTCModule"];
     v.clipsToBounds = YES;

--- a/ios/RCTWebRTC/ScreenCaptureController.m
+++ b/ios/RCTWebRTC/ScreenCaptureController.m
@@ -29,6 +29,7 @@ NSString *const kRTCAppGroupIdentifier = @"RTCAppGroupIdentifier";
     self = [super init];
     if (self) {
         self.capturer = capturer;
+        self.deviceId = @"screen-capture";
     }
 
     return self;
@@ -53,6 +54,13 @@ NSString *const kRTCAppGroupIdentifier = @"RTCAppGroupIdentifier";
     [self.capturer stopCapture];
 }
 
+- (NSDictionary *)getSettings {
+    return @{
+        @"deviceId": self.deviceId,
+        @"groupId": @"",
+        @"frameRate" : @(30)
+    };
+}
 // MARK: CapturerEventsDelegate Methods
 
 - (void)capturerDidEnd:(RTCVideoCapturer *)capturer {

--- a/ios/RCTWebRTC/VideoCaptureController.h
+++ b/ios/RCTWebRTC/VideoCaptureController.h
@@ -13,6 +13,7 @@
 - (void)startCapture;
 - (void)stopCapture;
 - (void)switchCamera;
+- (void)applyConstraints:(NSDictionary *)constraints error:(NSError **)outError;
 
 @end
 #endif

--- a/ios/RCTWebRTC/WebRTCModule+RTCAudioSession.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCAudioSession.m
@@ -1,0 +1,20 @@
+#import <objc/runtime.h>
+
+#import <React/RCTBridge.h>
+#import <React/RCTBridgeModule.h>
+
+#import "WebRTCModule.h"
+
+@implementation WebRTCModule (RTCAudioSession)
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(audioSessionDidActivate) {
+    [[RTCAudioSession sharedInstance] audioSessionDidActivate:[AVAudioSession sharedInstance]];
+    return nil;
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(audioSessionDidDeactivate) {
+    [[RTCAudioSession sharedInstance] audioSessionDidDeactivate:[AVAudioSession sharedInstance]];
+    return nil;
+}
+
+@end

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -77,12 +77,14 @@
         NSDictionary *settings = @{};
         if ([track.kind isEqualToString:@"video"]) {
             RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
-            if ([videoTrack.captureController isKindOfClass:[VideoCaptureController class]]) {
-                VideoCaptureController *vcc = (VideoCaptureController *)videoTrack.captureController;
-                AVCaptureDeviceFormat *format = vcc.selectedFormat;
-                CMVideoDimensions dimensions = CMVideoFormatDescriptionGetDimensions(format.formatDescription);
-                settings = @{@"height" : @(dimensions.height), @"width" : @(dimensions.width), @"frameRate" : @(30)};
+            if ([videoTrack.captureController isKindOfClass:[CaptureController class]]) {
+                settings = [videoTrack.captureController getSettings];
             }
+        } else if ([track.kind isEqualToString:@"audio"]) {
+            settings = @{
+                @"deviceId": @"audio",
+                @"groupId": @"",
+            };
         }
 
         [trackInfos addObject:@{
@@ -234,10 +236,14 @@ RCT_EXPORT_METHOD(getUserMedia
         NSDictionary *settings = @{};
         if ([track.kind isEqualToString:@"video"]) {
             RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
-            VideoCaptureController *vcc = (VideoCaptureController *)videoTrack.captureController;
-            AVCaptureDeviceFormat *format = vcc.selectedFormat;
-            CMVideoDimensions dimensions = CMVideoFormatDescriptionGetDimensions(format.formatDescription);
-            settings = @{@"height" : @(dimensions.height), @"width" : @(dimensions.width), @"frameRate" : @(30)};
+            if ([videoTrack.captureController isKindOfClass:[CaptureController class]]) {
+                settings = [videoTrack.captureController getSettings];
+            }
+        } else if ([track.kind isEqualToString:@"audio"]) {
+            settings = @{
+                @"deviceId": @"audio",
+                @"groupId": @"",
+            };
         }
 
         [tracks addObject:@{
@@ -267,11 +273,11 @@ RCT_EXPORT_METHOD(enumerateDevices : (RCTResponseSenderBlock)callback) {
     if (@available(macos 14.0, ios 17.0, tvos 17.0, *)) {
         [deviceTypes addObject:AVCaptureDeviceTypeExternal];
     }
-    AVCaptureDeviceDiscoverySession *videoevicesSession =
+    AVCaptureDeviceDiscoverySession *videoDevicesSession =
         [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:deviceTypes
                                                                mediaType:AVMediaTypeVideo
                                                                 position:AVCaptureDevicePositionUnspecified];
-    for (AVCaptureDevice *device in videoevicesSession.devices) {
+    for (AVCaptureDevice *device in videoDevicesSession.devices) {
         NSString *position = @"unknown";
         if (device.position == AVCaptureDevicePositionBack) {
             position = @"environment";
@@ -397,14 +403,32 @@ RCT_EXPORT_METHOD(mediaStreamTrackSetEnabled : (nonnull NSNumber *)pcId : (nonnu
 #endif
 }
 
-RCT_EXPORT_METHOD(mediaStreamTrackSwitchCamera : (nonnull NSString *)trackID) {
+RCT_EXPORT_METHOD(mediaStreamTrackApplyConstraints : (nonnull NSString *)trackID : (NSDictionary *)constraints : (RCTPromiseResolveBlock)resolve : (RCTPromiseRejectBlock)reject) {
 #if TARGET_OS_TV
+    reject(@"unsupported_platform", @"tvOS is not supported", nil);
     return;
 #else
     RTCMediaStreamTrack *track = self.localTracks[trackID];
     if (track) {
-        RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
-        [(VideoCaptureController *)videoTrack.captureController switchCamera];
+        if ([track.kind isEqualToString:@"video"]) {
+            RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
+            if ([videoTrack.captureController isKindOfClass:[CaptureController class]]) {
+                CaptureController *vcc = (CaptureController *)videoTrack.captureController;
+                NSError* error = nil;
+                [vcc applyConstraints:constraints error:&error];
+                if (error) {
+                    reject(@"E_INVALID", error.localizedDescription, error);
+                } else {
+                    resolve([vcc getSettings]);
+                }
+            }
+        } else {
+            RCTLogWarn(@"mediaStreamTrackApplyConstraints() track is not video");
+            reject(@"E_INVALID", @"Can't apply constraints on audio tracks", nil);
+        }
+    } else {
+        RCTLogWarn(@"mediaStreamTrackApplyConstraints() track is null");
+        reject(@"E_INVALID", @"Could not get track", nil);
     }
 #endif
 }

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -262,7 +262,8 @@ RCT_EXPORT_METHOD(enumerateDevices : (RCTResponseSenderBlock)callback) {
     callback(@[]);
 #else
     NSMutableArray *devices = [NSMutableArray array];
-    NSMutableArray *deviceTypes = @[ AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInUltraWideCamera, AVCaptureDeviceTypeBuiltInTelephotoCamera, AVCaptureDeviceTypeBuiltInDualCamera, AVCaptureDeviceTypeBuiltInDualWideCamera, AVCaptureDeviceTypeBuiltInTripleCamera];
+    NSMutableArray *deviceTypes = [NSMutableArray array];
+    [deviceTypes addObjectsFromArray:@[ AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInUltraWideCamera, AVCaptureDeviceTypeBuiltInTelephotoCamera, AVCaptureDeviceTypeBuiltInDualCamera, AVCaptureDeviceTypeBuiltInDualWideCamera, AVCaptureDeviceTypeBuiltInTripleCamera]];
     if (@available(macos 14.0, ios 17.0, tvos 17.0, *)) {
         [deviceTypes addObject:AVCaptureDeviceTypeExternal];
     }

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -262,8 +262,12 @@ RCT_EXPORT_METHOD(enumerateDevices : (RCTResponseSenderBlock)callback) {
     callback(@[]);
 #else
     NSMutableArray *devices = [NSMutableArray array];
+    NSMutableArray *deviceTypes = @[ AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInUltraWideCamera, AVCaptureDeviceTypeBuiltInTelephotoCamera, AVCaptureDeviceTypeBuiltInDualCamera, AVCaptureDeviceTypeBuiltInDualWideCamera, AVCaptureDeviceTypeBuiltInTripleCamera];
+    if (@available(macos 14.0, ios 17.0, tvos 17.0, *)) {
+        [deviceTypes addObject:AVCaptureDeviceTypeExternal];
+    }
     AVCaptureDeviceDiscoverySession *videoevicesSession =
-        [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[ AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeBuiltInUltraWideCamera, AVCaptureDeviceTypeBuiltInTelephotoCamera, AVCaptureDeviceTypeBuiltInDualCamera, AVCaptureDeviceTypeBuiltInDualWideCamera, AVCaptureDeviceTypeBuiltInTripleCamera]
+        [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:deviceTypes
                                                                mediaType:AVMediaTypeVideo
                                                                 position:AVCaptureDevicePositionUnspecified];
     for (AVCaptureDevice *device in videoevicesSession.devices) {
@@ -277,6 +281,7 @@ RCT_EXPORT_METHOD(enumerateDevices : (RCTResponseSenderBlock)callback) {
         if (device.localizedName != nil) {
             label = device.localizedName;
         }
+        
         [devices addObject:@{
             @"facing" : position,
             @"deviceId" : device.uniqueID,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-webrtc",
-  "version": "124.0.3",
+  "version": "124.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-webrtc",
-      "version": "124.0.3",
+      "version": "124.0.4",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-webrtc",
-  "version": "124.0.1",
+  "version": "124.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-webrtc",
-      "version": "124.0.1",
+      "version": "124.0.2",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-webrtc",
-  "version": "124.0.2",
+  "version": "124.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-webrtc",
-      "version": "124.0.2",
+      "version": "124.0.3",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webrtc",
-  "version": "124.0.3",
+  "version": "124.0.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/react-native-webrtc/react-native-webrtc.git"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "scripts": {
     "lint": "eslint --max-warnings 0 . && tsc --noEmit",
+    "lintfix": "eslint --max-warnings 0 --fix . && tsc --noEmit",
     "prepare": "husky install && bob build",
     "format": "tools/format.sh"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webrtc",
-  "version": "124.0.2",
+  "version": "124.0.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/react-native-webrtc/react-native-webrtc.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webrtc",
-  "version": "124.0.1",
+  "version": "124.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/react-native-webrtc/react-native-webrtc.git"

--- a/src/Constraints.ts
+++ b/src/Constraints.ts
@@ -1,0 +1,21 @@
+
+export type MediaTrackConstraints = {
+    width?: ConstrainNumber;
+    height?: ConstrainNumber;
+    frameRate?: ConstrainNumber;
+    facingMode?: ConstrainString;
+    deviceId?: ConstrainString;
+    groupId?: ConstrainString;
+}
+
+type ConstrainNumber = number | {
+    exact?: number,
+    ideal?: number,
+    max?: number,
+    min?: number,
+}
+
+type ConstrainString = string | {
+    exact?: string,
+    ideal?: string,
+}

--- a/src/MediaDevices.ts
+++ b/src/MediaDevices.ts
@@ -2,7 +2,7 @@ import { EventTarget, Event, defineEventAttribute } from 'event-target-shim/inde
 import { NativeModules } from 'react-native';
 
 import getDisplayMedia from './getDisplayMedia';
-import getUserMedia from './getUserMedia';
+import getUserMedia, { Constraints } from './getUserMedia';
 
 const { WebRTCModule } = NativeModules;
 
@@ -37,7 +37,7 @@ class MediaDevices extends EventTarget<MediaDevicesEventMap> {
      * @param {*} constraints
      * @returns {Promise}
      */
-    getUserMedia(constraints) {
+    getUserMedia(constraints: Constraints) {
         return getUserMedia(constraints);
     }
 }

--- a/src/RTCAudioSession.ts
+++ b/src/RTCAudioSession.ts
@@ -1,0 +1,25 @@
+import { NativeModules, Platform } from 'react-native';
+
+const { WebRTCModule } = NativeModules;
+
+export default class RTCAudioSession {
+    /**
+     * To be called when CallKit activates the audio session.
+     */
+    static audioSessionDidActivate() {
+        // Only valid for iOS
+        if (Platform.OS === 'ios') {
+            WebRTCModule.audioSessionDidActivate();
+        }
+    }
+
+    /**
+     * To be called when CallKit deactivates the audio session.
+     */
+    static audioSessionDidDeactivate() {
+        // Only valid for iOS
+        if (Platform.OS === 'ios') {
+            WebRTCModule.audioSessionDidDeactivate();
+        }
+    }
+}

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -739,6 +739,10 @@ export default class RTCPeerConnection extends EventTarget<RTCPeerConnectionEven
      * instance such as id
      */
     createDataChannel(label: string, dataChannelDict?: RTCDataChannelInit): RTCDataChannel {
+        if (arguments.length === 0) {
+            throw new TypeError('1 argument required, but 0 present');
+        }
+
         if (dataChannelDict && 'id' in dataChannelDict) {
             const id = dataChannelDict.id;
 
@@ -747,7 +751,7 @@ export default class RTCPeerConnection extends EventTarget<RTCPeerConnectionEven
             }
         }
 
-        const channelInfo = WebRTCModule.createDataChannel(this._pcId, label, dataChannelDict);
+        const channelInfo = WebRTCModule.createDataChannel(this._pcId, String(label), dataChannelDict);
 
         if (channelInfo === null) {
             throw new TypeError('Failed to create new DataChannel');

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -342,7 +342,7 @@ export default class RTCPeerConnection extends EventTarget<RTCPeerConnectionEven
 
         const newSdp = await WebRTCModule.peerConnectionAddICECandidate(
             this._pcId,
-            candidate.toJSON ? candidate.toJSON() : candidate
+            RTCUtil.deepClone(candidate)
         );
 
         this.remoteDescription = new RTCSessionDescription(newSdp);

--- a/src/RTCRtpParameters.ts
+++ b/src/RTCRtpParameters.ts
@@ -1,6 +1,7 @@
 import RTCRtcpParameters, { RTCRtcpParametersInit } from './RTCRtcpParameters';
 import RTCRtpCodecParameters, { RTCRtpCodecParametersInit } from './RTCRtpCodecParameters';
 import RTCRtpHeaderExtension, { RTCRtpHeaderExtensionInit } from './RTCRtpHeaderExtension';
+import { deepClone } from './RTCUtil';
 
 
 export interface RTCRtpParametersInit {
@@ -10,7 +11,7 @@ export interface RTCRtpParametersInit {
 }
 
 export default class RTCRtpParameters {
-    readonly codecs: RTCRtpCodecParameters[] = [];
+    codecs: (RTCRtpCodecParameters | RTCRtpCodecParametersInit)[] = [];
     readonly headerExtensions: RTCRtpHeaderExtension[] = [];
     readonly rtcp: RTCRtcpParameters;
 
@@ -26,11 +27,11 @@ export default class RTCRtpParameters {
         this.rtcp = new RTCRtcpParameters(init.rtcp);
     }
 
-    toJSON(): RTCRtpParametersInit {
+    toJSON() {
         return {
-            codecs: this.codecs.map(c => c.toJSON()),
-            headerExtensions: this.headerExtensions.map(he => he.toJSON()),
-            rtcp: this.rtcp.toJSON()
+            codecs: this.codecs.map(c => deepClone(c)),
+            headerExtensions: this.headerExtensions.map(he => deepClone(he)),
+            rtcp: deepClone(this.rtcp)
         };
     }
 }

--- a/src/RTCRtpSendParameters.ts
+++ b/src/RTCRtpSendParameters.ts
@@ -48,7 +48,7 @@ export default class RTCRtpSendParameters extends RTCRtpParameters {
         }
     }
 
-    toJSON(): RTCRtpSendParametersInit {
+    toJSON() {
         const obj = super.toJSON();
 
         obj['transactionId'] = this.transactionId;
@@ -58,6 +58,6 @@ export default class RTCRtpSendParameters extends RTCRtpParameters {
             obj['degradationPreference'] = DegradationPreference.toNative(this.degradationPreference);
         }
 
-        return obj as RTCRtpSendParametersInit;
+        return obj;
     }
 }

--- a/src/RTCRtpSendParameters.ts
+++ b/src/RTCRtpSendParameters.ts
@@ -1,5 +1,6 @@
 import RTCRtpEncodingParameters, { RTCRtpEncodingParametersInit } from './RTCRtpEncodingParameters';
 import RTCRtpParameters, { RTCRtpParametersInit } from './RTCRtpParameters';
+import { deepClone } from './RTCUtil';
 
 type DegradationPreferenceType = 'maintain-framerate'
     | 'maintain-resolution'
@@ -31,7 +32,7 @@ export interface RTCRtpSendParametersInit extends RTCRtpParametersInit {
 
 export default class RTCRtpSendParameters extends RTCRtpParameters {
     readonly transactionId: string;
-    readonly encodings: RTCRtpEncodingParameters[];
+    encodings: (RTCRtpEncodingParameters | RTCRtpEncodingParametersInit)[];
     degradationPreference: DegradationPreferenceType | null;
 
     constructor(init: RTCRtpSendParametersInit) {
@@ -51,8 +52,7 @@ export default class RTCRtpSendParameters extends RTCRtpParameters {
         const obj = super.toJSON();
 
         obj['transactionId'] = this.transactionId;
-
-        obj['encodings'] = this.encodings.map(e => e.toJSON());
+        obj['encodings'] = this.encodings.map(e => deepClone(e));
 
         if (this.degradationPreference !== null) {
             obj['degradationPreference'] = DegradationPreference.toNative(this.degradationPreference);

--- a/src/getUserMedia.ts
+++ b/src/getUserMedia.ts
@@ -2,6 +2,7 @@
 import { NativeModules } from 'react-native';
 
 
+import { MediaTrackConstraints } from './Constraints';
 import MediaStream from './MediaStream';
 import MediaStreamError from './MediaStreamError';
 import permissions from './Permissions';
@@ -9,9 +10,9 @@ import * as RTCUtil from './RTCUtil';
 
 const { WebRTCModule } = NativeModules;
 
-interface Constraints {
-    audio?: boolean | object;
-    video?: boolean | object;
+export interface Constraints {
+    audio?: boolean | MediaTrackConstraints;
+    video?: boolean | MediaTrackConstraints;
 }
 
 export default function getUserMedia(constraints: Constraints = {}): Promise<MediaStream> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import MediaStream from './MediaStream';
 import MediaStreamTrack from './MediaStreamTrack';
 import MediaStreamTrackEvent from './MediaStreamTrackEvent';
 import permissions from './Permissions';
+import RTCAudioSession from './RTCAudioSession';
 import RTCErrorEvent from './RTCErrorEvent';
 import RTCIceCandidate from './RTCIceCandidate';
 import RTCPeerConnection from './RTCPeerConnection';
@@ -40,6 +41,7 @@ export {
     RTCRtpReceiver,
     RTCRtpSender,
     RTCErrorEvent,
+    RTCAudioSession,
     MediaStream,
     MediaStreamTrack,
     mediaDevices,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { setupNativeEvents } from './EventEmitter';
 import Logger from './Logger';
 import mediaDevices from './MediaDevices';
 import MediaStream from './MediaStream';
-import MediaStreamTrack from './MediaStreamTrack';
+import MediaStreamTrack, { type MediaTrackSettings } from './MediaStreamTrack';
 import MediaStreamTrackEvent from './MediaStreamTrackEvent';
 import permissions from './Permissions';
 import RTCAudioSession from './RTCAudioSession';
@@ -44,6 +44,7 @@ export {
     RTCAudioSession,
     MediaStream,
     MediaStreamTrack,
+    type MediaTrackSettings,
     mediaDevices,
     permissions,
     registerGlobals


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `5fdb6ad..f3f3301`
**Files Changed:** 33 (16 programming files)
**Programming Ratio:** 48.5%

**Commits included:**
- ios,android: add device/groupId to MediaStreamTrack.getSettings and implement applyConstraints (#1615)
- ios: Add RTCAudioSession helper methods needed for CallKit (#1614)
- release 124.0.4
- misc: make serialization more resilient
- sender: fix serializing RTCRtpSendParameters
- android: remove no longer used replace rule from manifest (#1609)
- ios: fix exception in iOS 17+ w/ Xcode 15.4
- android: report actual size in camera MediaStreamTrack settings (#1598)
- pc: align createDataChannel with standard
- ci: remove flipper from gumtestapp (#1608)
... and 5 more commits